### PR TITLE
kb: clarifications for renewing cloud credentials

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -134,7 +134,7 @@ const config = {
         showReadingTime: true,
         // Please change this to your repo.
         editUrl:
-          "https://github.com/harvester/harvesterhci.io/edit/main/kb/",
+          "https://github.com/harvester/harvesterhci.io/edit/main/",
         blogTitle: 'Harvester HCI knowledge base',
         routeBasePath: 'kb',
         include: ['**/*.{md,mdx}'],

--- a/kb/2024-05-17/modify_cloud_credential_ttl.md
+++ b/kb/2024-05-17/modify_cloud_credential_ttl.md
@@ -42,8 +42,8 @@ You can patch the expired Harvester cloud credentials to use a new authenticatio
 
   ```shell
   #!/bin/sh
-  CLOUD_CREDENTIAL_NAME=$1
-  KUBECONFIG_FILE=$2
+  CLOUD_CREDENTIAL_ID=$1  # .metadata.name of the cloud credential
+  KUBECONFIG_FILE=$2      # path to the downloaded kubeconfig file
 
   kubeconfig="$(base64 -w 0 "${KUBECONFIG_FILE}")"
 
@@ -54,7 +54,7 @@ You can patch the expired Harvester cloud credentials to use a new authenticatio
     harvestercredentialConfig-kubeconfigContent: $kubeconfig
   EOF
 
-  kubectl patch secret ${CLOUD_CREDENTIAL_NAME} -n cattle-global-data --patch-file ${patch_file} --type merge
+  kubectl patch secret ${CLOUD_CREDENTIAL_ID} -n cattle-global-data --patch-file ${patch_file} --type merge
   rm ${patch_file}
   ```
 


### PR DESCRIPTION
- Fix "Edit this page" link at the bottom of KB article pages

- Clarification for what is supposed to be the first parameter to the supplied script. The KB article detailing how to renew expired cloud credentials instructs users to use a little script, however some community users were confused by a discrepancy between the naming of parameters for the script and the naming of the corresponding properties in the Rancher UI. This change aligns the naming with the Rancher UI and adds clarifications in form of comments.

related-to: https://github.com/rancher/rancher/issues/44912