### PR TITLE
kb: (cve-2025-1974) document steps to preserve default and any custom configuration

### DIFF
--- a/kb/2025-03-25/cve-2025-1974.md
+++ b/kb/2025-03-25/cve-2025-1974.md
@@ -28,11 +28,20 @@ kubectl -n kube-system get po -l"app.kubernetes.io/name=rke2-ingress-nginx" -ojs
 
 If the command returns one of the affected versions, disable the `rke2-ingress-nginx-admission` validating webhook configuration by performing the following steps:
 
-1. On one of your control plane nodes, locate the file `/var/lib/rancher/rke2/server/manifests/rke2-ingress-nginx-config.yaml`.
+1. On one of your control plane nodes, use `kubectl` to confirm the existence of the `HelmChartConfig` resource named `rke2-ingress-nginx`:
 
-    If the file does not exist, you must create the file at the specified location with the exact same file name.
+   ```sh
+   $ kubectl -n kube-system get helmchartconfig rke2-ingress-nginx
+   NAME                 AGE
+   rke2-ingress-nginx   14d1h
+   ```
 
-1. Add the following configuration to the file:
+1. Use `kubectl -n kube-system edit helmchartconfig rke2-ingress-nginx` to add the following configurations to the resource:
+
+    * `.spec.valuesContent.controller.admissionWebhooks.enabled: false`
+    * `.spec.valuesContent.controller.extraArgs.enable-annotation-validation: true`
+
+1. The following is an example of what the updated `.spec.valuesContent` configuration along with the default Harvester ingress-nginx configuration should look like:
 
   ```yaml
   apiVersion: helm.cattle.io/v1
@@ -44,6 +53,7 @@ If the command returns one of the affected versions, disable the `rke2-ingress-n
     valuesContent: |-
       controller:
         admissionWebhooks:
+          port: 8444
           enabled: false
         extraArgs:
           enable-annotation-validation: true
@@ -55,33 +65,32 @@ If the command returns one of the affected versions, disable the `rke2-ingress-n
           pathOverride: kube-system/ingress-expose
   ```
 
-    Harvester automatically applies the change once the content is saved.
+   Exit the `kubectl edit` command execution to save the configuration. 
 
+   Harvester automatically applies the change once the content is saved.
 
-:::info important
+ :::info important
 
-The configuration disables the RKE2 ingress-nginx admission webhooks while preserving Harvester's default ingress-nginx configuration.
+   The configuration disables the RKE2 ingress-nginx admission webhooks while preserving Harvester's default ingress-nginx configuration.
 
-If other custom `rke2-ingress-nginx` configurations exist, you must merge those with the above configuration under the same `HelmChartConfig` resource.
+   If the `HelmChartConfig` resource contains other custom ingress-nginx configuration, you must retain them when editing the resource.
 
-Use the `kubectl -n kube-system get helmchartconfig rke2-ingress-nginx -oyaml` command to check for existing custom configurations.
-
-:::
+ :::
 
 1. Verify that RKE2 deleted the `rke2-ingress-nginx-admission` validating webhook configuration.
 
-```sh
-$ kubectl get validatingwebhookconfiguration rke2-ingress-nginx-admission
-Error from server (NotFound): validatingwebhookconfigurations.admissionregistration.k8s.io "rke2-ingress-nginx-admission" not found
-```
+   ```sh
+   $ kubectl get validatingwebhookconfiguration rke2-ingress-nginx-admission
+   Error from server (NotFound): validatingwebhookconfigurations.admissionregistration.k8s.io "rke2-ingress-nginx-admission" not found
+   ```
 
 1. Verify that the ingress-nginx pods are restarted successfully.
 
-```sh
-$ kubectl -n kube-system get po -lapp.kubernetes.io/instance=rke2-ingress-nginx
-NAME                                  READY   STATUS    RESTARTS   AGE
-rke2-ingress-nginx-controller-g8l49   1/1     Running   0          5s
-```
+   ```sh
+   $ kubectl -n kube-system get po -lapp.kubernetes.io/instance=rke2-ingress-nginx
+   NAME                                  READY   STATUS    RESTARTS   AGE
+   rke2-ingress-nginx-controller-g8l49   1/1     Running   0          5s
+   ```
 
 Once your Harvester cluster receives the RKE2 ingress-nginx patch, you can re-install the `rke2-ingress-nginx-admission` validating webhook configuration by removing the `HelmChartConfig` patch.
 

--- a/kb/2025-03-25/cve-2025-1974.md
+++ b/kb/2025-03-25/cve-2025-1974.md
@@ -20,11 +20,6 @@ The vulnerability affects specific versions of the RKE2 ingress-nginx controller
 
 A security issue was discovered in Kubernetes where under certain conditions, an unauthenticated attacker with access to the pod network can achieve arbitrary code execution in the context of the ingress-nginx controller. This can lead to disclosure of secrets accessible to the controller. (Note that in the default installation, the controller can access all secrets cluster-wide.)
 
-Your Harvester cluster is affected by this vulnerability if:
-
-- the RKE2 ingress-nginx controller is installed, and
-- the pods are running version v1.12.0 or all versions prior to v1.11.4 (included)
-
 You can confirm the version of the RKE2 ingress-nginx pods by running this command on your Harvester cluster:
 
 ```sh
@@ -33,9 +28,11 @@ kubectl -n kube-system get po -l"app.kubernetes.io/name=rke2-ingress-nginx" -ojs
 
 If the command returns one of the affected versions, disable the `rke2-ingress-nginx-admission` validating webhook configuration by performing the following steps:
 
-1. On one of your control plane nodes, create the file `/var/lib/rancher/rke2/server/manifests/rke2-ingress-nginx-config.yaml`.
+1. On one of your control plane nodes, locate the file `/var/lib/rancher/rke2/server/manifests/rke2-ingress-nginx-config.yaml`.
 
-1. Add the following content to the file:
+    If the file does not exist, you must create the file at the specified location with the exact same file name.
+
+1. Add the following configuration to the file:
 
   ```yaml
   apiVersion: helm.cattle.io/v1
@@ -50,18 +47,46 @@ If the command returns one of the affected versions, disable the `rke2-ingress-n
           enabled: false
         extraArgs:
           enable-annotation-validation: true
+          default-ssl-certificate: cattle-system/tls-rancher-internal
+        config:
+          proxy-body-size: "0"
+          proxy-request-buffering: "off"
+        publishService:
+          pathOverride: kube-system/ingress-expose
   ```
 
     Harvester automatically applies the change once the content is saved.
 
-RKE2 deletes the `rke2-ingress-nginx-admission` validating webhook configuration and restarts the ingress-nginx pods.
-
-Once your Harvester cluster receives the RKE2 ingress-nginx patch, you can re-install the `rke2-ingress-nginx-admission` validating webhook configuration by removing the `HelmChartConfig` workaround.
 
 :::info important
 
-These steps only cover the RKE2 ingress-nginx controller that is managed by Harvester. You must also update other running ingress-nginx controllers. See the References section for more information.
+The configuration disables the RKE2 ingress-nginx admission webhooks while preserving Harvester's default ingress-nginx configuration.
 
+If other custom `rke2-ingress-nginx` configurations exist, you must merge those with the above configuration under the same `HelmChartConfig` resource.
+
+Use the `kubectl -n kube-system get helmchartconfig rke2-ingress-nginx -oyaml` command to check for existing custom configurations.
+
+:::
+
+1. Verify that RKE2 deleted the `rke2-ingress-nginx-admission` validating webhook configuration.
+
+```sh
+$ kubectl get validatingwebhookconfiguration rke2-ingress-nginx-admission
+Error from server (NotFound): validatingwebhookconfigurations.admissionregistration.k8s.io "rke2-ingress-nginx-admission" not found
+```
+
+1. Verify that the ingress-nginx pods are restarted successfully.
+
+```sh
+$ kubectl -n kube-system get po -lapp.kubernetes.io/instance=rke2-ingress-nginx
+NAME                                  READY   STATUS    RESTARTS   AGE
+rke2-ingress-nginx-controller-g8l49   1/1     Running   0          5s
+```
+
+Once your Harvester cluster receives the RKE2 ingress-nginx patch, you can re-install the `rke2-ingress-nginx-admission` validating webhook configuration by removing the `HelmChartConfig` patch.
+
+:::info important
+These steps only cover the RKE2 ingress-nginx controller that is managed by Harvester. You must also update other running ingress-nginx controllers. See the References section for more information.
 :::
 
 ## References


### PR DESCRIPTION
Update the CVE-2025-1974 KB to include steps to preserve Harvester's default and other custom ingress configuration.

Issue: https://github.com/harvester/harvester/issues/7941