### PR TITLE
kb: (cve-2025-1974) update cve article to include fix versions

### DIFF
--- a/kb/2025-03-25/cve-2025-1974.md
+++ b/kb/2025-03-25/cve-2025-1974.md
@@ -14,8 +14,12 @@ hide_table_of_contents: false
 
 **CVE-2025-1974** (vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H) has a score of [9.8 (Critical)](https://www.first.org/cvss/calculator/3-1#CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H).
 
-The vulnerability affects specific versions of the RKE2 ingress-nginx controller (v.1.11.4 and earlier, and v1.12.0). All Harvester versions that use this controller (including v1.4.2 and later) are therefore affected.
+The vulnerability affects specific versions of the RKE2 ingress-nginx controller (v.1.11.4 and earlier, and v1.12.0). All Harvester versions that use this controller (including v1.4.2 and earlier) are therefore affected.
 
+:::
+
+:::info important
+This CVE is fixed in Harvester 1.5.0, 1.4.3 and newer.
 :::
 
 A security issue was discovered in Kubernetes where under certain conditions, an unauthenticated attacker with access to the pod network can achieve arbitrary code execution in the context of the ingress-nginx controller. This can lead to disclosure of secrets accessible to the controller. (Note that in the default installation, the controller can access all secrets cluster-wide.)

--- a/kb/2025-03-25/cve-2025-1974.md
+++ b/kb/2025-03-25/cve-2025-1974.md
@@ -10,16 +10,13 @@ tags: [security, cve]
 hide_table_of_contents: false
 ---
 
-:::warning
+:::important
 
 **CVE-2025-1974** (vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H) has a score of [9.8 (Critical)](https://www.first.org/cvss/calculator/3-1#CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H).
 
 The vulnerability affects specific versions of the RKE2 ingress-nginx controller (v.1.11.4 and earlier, and v1.12.0). All Harvester versions that use this controller (including v1.4.2 and earlier) are therefore affected.
 
-:::
-
-:::info important
-This CVE is fixed in Harvester 1.5.0, 1.4.3 and newer.
+**This CVE is fixed in Harvester 1.5.0, 1.4.3 and newer.**
 :::
 
 A security issue was discovered in Kubernetes where under certain conditions, an unauthenticated attacker with access to the pod network can achieve arbitrary code execution in the context of the ingress-nginx controller. This can lead to disclosure of secrets accessible to the controller. (Note that in the default installation, the controller can access all secrets cluster-wide.)

--- a/kb/2025-03-25/cve-2025-1974.md
+++ b/kb/2025-03-25/cve-2025-1974.md
@@ -10,7 +10,7 @@ tags: [security, cve]
 hide_table_of_contents: false
 ---
 
-:::important
+:::info important
 
 **CVE-2025-1974** (vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H) has a score of [9.8 (Critical)](https://www.first.org/cvss/calculator/3-1#CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H).
 


### PR DESCRIPTION
This PR updates the CVE-2025-1974 KB article to identify versions of Harvester with the fixes. The actual steps to revert the earlier workaround are included in the community upgrade docs.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/7956