### PR TITLE
ci: upgrade setup-node to v4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: 16.x
           cache: yarn

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: 16.x
           cache: yarn


### PR DESCRIPTION
This PR upgrades the `setup-node` GHA to v4. The v2 depends on a deprecated cache action which was permanently shutdown on 04/15/2005. This upgrade resolves the `Error: Cache service responded with 422` issue, as seen in https://github.com/harvester/harvesterhci.io/actions/runs/14624141634.

Relevant: https://github.com/actions/setup-node/issues/1275#issuecomment-2814607336