### PR TITLE
fix: correct editUrl path for docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -26,7 +26,7 @@ const config = {
                     sidebarPath: require.resolve("./sidebars.js"),
                     // Please change this to your repo.
                     editUrl:
-                        "https://github.com/harvester/harvesterhci.io/edit/main/static/",
+                        "https://github.com/harvester/harvesterhci.io/edit/main/",
                 },
                 theme: {
                     customCss: require.resolve("./src/css/custom.css"),


### PR DESCRIPTION
#### Problem:
The "Edit this page" links on the Harvester documentation site are broken and redirect to incorrect paths.

#### Solution:
Updated the `editUrl` in `docusaurus.config.js` to point to the correct base path. The previous configuration incorrectly referenced `/static/`, while documentation files are located under `/docs/`.

#### Related Issue(s):
Issue harvester/harvester#10323

#### Test plan:
1. Open a documentation page locally or after deployment
2. Click on "Edit this page"
3. Verify that it redirects to the correct file under `/docs/` in the GitHub repository

#### Additional documentation or context:
This change ensures that contributors can directly navigate to the correct source files when editing documentation pages.
