### PR TITLE
GHA: update upload-pages-artifact to v4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
           yarn build
       - name: Upload static files as artifact
         id: deployment
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: ./build
   release:


### PR DESCRIPTION
CI failed https://github.com/harvester/harvesterhci.io/actions/runs/24148739348/job/70469559085
```
Error: The action actions/upload-artifact@v4 is not allowed in harvester/harvesterhci.io because all actions must be from a repository owned by your enterprise, created by GitHub, or match one of the patterns: anchore/sbom-action/download-syft@*, aquasecurity/*, aws-actions/*, azure/*, changesets/action@*, changesets/bot@*, codecov/codecov-action@*, crate-ci/typos@*, docker/*, docker://gcr.io/kaniko-project/executor:*, fossas/fossa-action@*, golang/*, golangci/*, google-github-actions/*, google/*, googleapis/release-please-action@*, goreleaser/*, hashicorp/setup-packer@*, hashicorp/setup-terraform@*, hashicorp/vault-action@*, helm/*, kubernetes-sigs/*, kubernetes/*, kubewarden/kubewarden-end-to-end-tests@*, neuvector/*, openvex/setup-vexctl@*, oras-project/setup-oras@*, ossf/scorecard-action@*, rancher-eio/*, rancher-sandbox/azure-janitor@*, rancher-sandbox/highlander-reusable-workflows/*, rancher/*, rancherlabs/*, renovatebot/*, ruby/*, runs-on/cache@*, rustsec/audit-check@*, sigstore/cos...
```
upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa use tag instead of sha in
https://github.com/actions/upload-pages-artifact/blob/56afc609e74202658d3ffba0e8f6dda462b719fa/action.yml#L77

Since we enable the pinned commit sha rule, we need to update the upload-pages-artifact to v4 ([7b1f4a764d45c48632c6b24a0339c27f5614fb0b](https://github.com/actions/upload-pages-artifact/commit/7b1f4a764d45c48632c6b24a0339c27f5614fb0b))
https://github.com/actions/upload-pages-artifact/blob/v4/action.yml#L80